### PR TITLE
fix(components): resolve vue prop validation warnings

### DIFF
--- a/src/components/atoms/formCounter/FormCounter.vue
+++ b/src/components/atoms/formCounter/FormCounter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
     type FormCounterProps = {
-        remainingCharacters: number;
+        remainingCharacters?: number;
     };
 
     const props = withDefaults(defineProps<FormCounterProps>(), {

--- a/src/components/molecules/formInput/FormInput.vue
+++ b/src/components/molecules/formInput/FormInput.vue
@@ -4,9 +4,9 @@
     import Eye from "../../atoms/icons/external/Eye.vue";
 
     type FormInputProps = {
-        id?: string;
+        id: string;
         type?: string;
-        placeholder?: string;
+        placeholder: string;
         isDisabled?: boolean;
     };
 

--- a/src/components/molecules/formTextArea/FormTextArea.vue
+++ b/src/components/molecules/formTextArea/FormTextArea.vue
@@ -3,8 +3,8 @@
     import { ref, computed } from "vue";
 
     type FormTextAreaProps = {
-        placeholder: string;
         maxLength: number;
+        placeholder?: string;
     };
 
     const props = withDefaults(defineProps<FormTextAreaProps>(), {

--- a/src/components/molecules/toast/Toast.vue
+++ b/src/components/molecules/toast/Toast.vue
@@ -3,17 +3,19 @@
 
     export type ToastProps = {
         title: string;
-        description?: string;
-        type: "short" | "descriptive" | "action";
-        variant: "info" | "error";
-        visible: boolean;
-        actionLabel?: string;
+        description?: string | null;
+        type?: "short" | "descriptive" | "action";
+        variant?: "info" | "error";
+        visible?: boolean;
+        actionLabel?: string | null;
     };
 
     const props = withDefaults(defineProps<ToastProps>(), {
+        description: null,
         type: "short",
         variant: "info",
         visible: true,
+        actionLabel: null,
     });
 
     const emits = defineEmits<{


### PR DESCRIPTION
## Description

Fix Vue.js prop validation warnings in form components. Corrected prop definitions to resolve ESLint warnings about required props with default values and missing default values.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Code refactoring
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A

## Additional Notes

N/A
