### PR TITLE
chore(github): restructure pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/large_changes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/large_changes.md
@@ -19,7 +19,6 @@ Closes #(issue_number)
 
 - [ ] My code follows the project's style guidelines
 - [ ] I have performed a self-review of my code
-- [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 
 ## Screenshots (if applicable)

--- a/.github/PULL_REQUEST_TEMPLATE/medium_changes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/medium_changes.md
@@ -1,0 +1,25 @@
+## Description
+
+Brief description of the changes made.
+
+## Related Issue
+
+Closes #(issue_number) or N/A
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Code refactoring
+- [ ] Documentation update
+- [ ] Performance improvement
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] My changes generate no new warnings
+
+## Additional Notes
+
+<!-- Any additional context or information -->

--- a/.github/PULL_REQUEST_TEMPLATE/small_changes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/small_changes.md
@@ -1,0 +1,16 @@
+## Description
+
+Brief description of the changes made.
+
+## Type of Change
+
+- [ ] Configuration update
+- [ ] Code formatting/linting
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] Dependency update
+
+## Checklist
+
+- [ ] My changes generate no new warnings
+- [ ] I have tested the changes locally


### PR DESCRIPTION
## Description
Create separate PR templates for small, medium, and large changes based on impact level. Remove the existing general template and replace it with three targeted templates to better match the scope of different types of changes.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Code refactoring
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Screenshots (if applicable)
N/A

## Additional Notes
Added three templates: `large.md` (major features/breaking changes), `medium.md` (component updates/bug fixes), and `small.md` (config/linting/minor tweaks)
Each template has appropriate fields for its change scope
Contributors can now select the most relevant template when creating a PR
Removes friction for small changes while maintaining thoroughness for large ones